### PR TITLE
Display db records on map and center on given footprints

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -82,7 +82,8 @@ export class HomeComponent implements OnInit {
     //       ]
     //     ],
     //     crs: { type: 'name', properties: { name: 'EPSG:4326'} }
-    //   }
+    //   },
+    //   ubid: "test value 1"
     // }).catch((err) => { 
     //   console.log(err);
     // });
@@ -114,7 +115,8 @@ export class HomeComponent implements OnInit {
     //       ]
     //     ],
     //     crs: { type: 'name', properties: { name: 'EPSG:4326'} }
-    //   }
+    //   },
+    //   ubid: "test value 2"
     // }).catch((err) => { 
     //   console.log(err);
     // });
@@ -132,7 +134,8 @@ export class HomeComponent implements OnInit {
     //       ]
     //     ],
     //     crs: { type: 'name', properties: { name: 'EPSG:4326'} }
-    //   }
+    //   },
+    //   ulid: "test value 3"
     // }).catch((err) => { 
     //   console.log(err);
     // });
@@ -149,8 +152,9 @@ export class HomeComponent implements OnInit {
     //         [37.39262499999998, -121.9214062499999] 
     //       ]
     //     ],
-    //     crs: { type: 'name', properties: { name: 'EPSG:4326'} }
-    //   }
+    //     crs: { type: 'name', properties: { name: 'EPSG:4326'} },
+    //   },
+    //   ulid: "test value 4"
     // }).catch((err) => { 
     //   console.log(err);
     // });


### PR DESCRIPTION
When testing this, use the commented out code on the home component by uncommenting it and clicking on the Test Button. This will seed your DB with 4 examples records (2 properties, 2 tax lots).

The footprint geometries shown are generated by DB records. The info box is currently populated by UBID/ULID. More design is needed there.
![Screen Shot 2020-10-07 at 2 47 54 PM](https://user-images.githubusercontent.com/30608004/95386166-1c78ad80-08ac-11eb-813b-035c6a196347.png)


Also, this assumes DB has been init and migrations were run. These would hopefully be checked automatically in the future (vs starting and stopping via buttons).
